### PR TITLE
Booking HTTP Status Codes and Modals

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -28,5 +28,8 @@
   "su": "So",
   "minutes": "Minuten",
   "please_select": "Please Select",
-  "are_you_sure": "Are you sure to apply booking?"
+  "are_you_sure": "Are you sure to apply booking?",
+  "successful_booking": "Successful Booking",
+  "booking_issue": "We had an issue during booking:",
+  "yes": "Yes"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -28,5 +28,8 @@
   "su": "So",
   "minutes": "Minutes",
   "please_select": "Please Select",
-  "are_you_sure": "Are you sure to apply booking?"
+  "are_you_sure": "Are you sure to apply booking?",
+  "successful_booking": "Successful Booking",
+  "booking_issue": "We had an issue during booking:",
+  "yes": "Yes"
 }

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -4,8 +4,8 @@ $configs = include(__DIR__ . '/../config.php');
 
 class SQLMgr {
     private $connection;
-    protected string $lastError;
-    protected int $lastErrno;
+    public string $lastError;
+    public int $lastErrno;
     public function __construct()
     {
         global $configs;

--- a/script.js
+++ b/script.js
@@ -80,6 +80,97 @@ document.body.onclick = (e) =>{
     }
 }
 
+function BSModal (options) {
+    if (!options) options = {};
+    let mainModal = document.querySelector('#bsModal');
+    if (mainModal) {
+        mainModal.outerHTML = '';
+    }
+    const modalClose = (button, index) => {
+        if (currentModal) {
+            currentModal.close();
+        } else {
+            mainModal.outerHTML = '';
+        }
+        if (typeof options.onclose === "function") {
+            options.onclose(button, index);
+        }
+    };
+    mainModal = document.createElement('div');
+    mainModal.id = 'bsModal';
+    mainModal.className = 'modal fade';
+
+    const dialog = document.createElement('div');
+    dialog.classList.add('modal-dialog');
+    const content = document.createElement('div');
+    content.classList.add('modal-content');
+
+    const header  = document.createElement('div');
+    header.classList.add('modal-header');
+    const title = document.createElement('h5');
+    title.classList.add('modal-title');
+    title.innerHTML = options.title || 'Modal';
+    const close = document.createElement('button');
+    close.setAttribute('type', 'button');
+    close.classList.add('btn-close');
+    close.onclick = ()=>modalClose();
+    header.appendChild(title);
+    header.appendChild(close);
+
+    const body  = document.createElement('div');
+    body.classList.add('modal-body');
+
+    if (options.body instanceof Node || options.body instanceof Element) {
+        body.appendChild(options.body);
+    } else if (typeof options.body === "string") {
+        body.innerHTML = options.body;
+    }
+
+    content.appendChild(header);
+    content.appendChild(body);
+
+    if (Array.isArray(options.buttons)) {
+        const footer = document.createElement('div');
+        footer.classList.add('modal-footer');
+
+        options.buttons.forEach((button, index)=> {
+            if (!button) {
+                return;
+            }
+            const btn = document.createElement('button');
+            btn.setAttribute('type', 'button');
+            btn.classList.add('btn');
+            btn.classList.add('btn-primary');
+            if (typeof button === 'string') {
+                btn.innerHTML = button;
+                btn.onclick = ()=> modalClose(button, index);
+            } else if (typeof button === 'object') {
+                btn.innerHTML = button.innerHTML || button.value || button.text || 'OK';
+                if (typeof options.onclick === 'function') {
+                    btn.onclick = ()=>options.onclick(mainModal);
+                } else {
+                    btn.onclick = ()=> modalClose(button, index);
+                }
+                if (button.className) {
+                    btn.className = button.className;
+                }
+            }
+
+            footer.appendChild(btn);
+        })
+        content.appendChild(footer);
+    }
+
+
+    dialog.appendChild(content);
+
+    mainModal.appendChild(dialog);
+    document.body.appendChild(mainModal);
+
+    showModalFor(mainModal);
+
+}
+
 updateCalendar();
 
 const prevMonthBtn = document.getElementById('prevMonthBtn');


### PR DESCRIPTION
Added HTTP Statuses for booking like:
- No aufid or invalid: 400
- No wartdatum or wartzeit: 400
- No data for aufid: 404
- wartzeit is already there: 410: (to avoid double booking)
- SQL errors: 500
- Successful booking: 201


Added Bootstrap modals to handle booking confirmation and feedback messages.
![confirmation](https://github.com/CoderChef01/Calendar/assets/13684826/a424720d-b200-4921-a563-e26f02ac1de9) ![errors](https://github.com/CoderChef01/Calendar/assets/13684826/f44298ed-b9c6-4fec-8590-a7f108985164)


You can create your own Modal with the following examples:

`const modalConfig = {
        title: 'Result',
        body: 'Test',
        buttons: ['OK']
    };
BSModal(modalConfig);`